### PR TITLE
Require >=PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Fork of rubengc/cmb2-field-ajax-search WordPress plugin with added Composer support",
     "type": "wordpress-plugin",
     "require": {
-        "php": ">=7.3"
+        "php": ">=7.1"
     },
     "version": "1.0.1",
     "keywords": ["wordpress"],


### PR DESCRIPTION
Testing backwards compatibility for php